### PR TITLE
Make Home and Food page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import styled from '@emotion/styled';
 
+import HomePage from './HomePage';
+
 const GridLayout = styled.div({
   display: 'grid',
   gridTemplateColumns: '1fr minmax(480px, 1fr) 1fr',
@@ -45,10 +47,7 @@ export default function App() {
             <h2>오늘 뭐 먹지?!</h2>
           </AppHeader>
           <AppContent>
-            <h1>오늘 뭐 먹지?!</h1>
-            <p>무엇을 먹을지 고민이라면,</p>
-            <p>오늘 한 끼 여기에 맡겨라!</p>
-            <button type="button">메뉴 뽑기</button>
+            <HomePage />
           </AppContent>
           <AppFooter />
         </AppContainer>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
 
+import {
+  Switch,
+  Route,
+  Link,
+} from 'react-router-dom';
+
 import styled from '@emotion/styled';
 
 import HomePage from './HomePage';
+
+import FoodPage from './FoodPage';
 
 const GridLayout = styled.div({
   display: 'grid',
@@ -44,10 +52,15 @@ export default function App() {
       <Section>
         <AppContainer>
           <AppHeader>
-            <h2>오늘 뭐 먹지?!</h2>
+            <h2>
+              <Link to="/">오늘 뭐 먹지?!</Link>
+            </h2>
           </AppHeader>
           <AppContent>
-            <HomePage />
+            <Switch>
+              <Route exact path="/" component={HomePage} />
+              <Route exact path="/food" component={FoodPage} />
+            </Switch>
           </AppContent>
           <AppFooter />
         </AppContainer>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import App from './App';
 
@@ -9,22 +9,9 @@ describe('App', () => {
     return render(<App />);
   }
 
-  it('renders title and subtitle', () => {
+  it('renders header', () => {
     const { container } = renderApp();
 
     expect(container).toHaveTextContent(/오늘 뭐 먹지/);
-
-    expect(container).toHaveTextContent(/무엇을 먹을지 고민이라면/);
-    expect(container).toHaveTextContent(/오늘 한 끼 여기에 맡겨라/);
-  });
-
-  it('renders "메뉴 뽑기" button ', () => {
-    const { getByText } = renderApp();
-
-    const button = getByText('메뉴 뽑기');
-
-    expect(button).not.toBeNull();
-
-    fireEvent.click(button);
   });
 });

--- a/src/FoodPage.jsx
+++ b/src/FoodPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function FoodPage() {
+  return (
+    <>
+      <h1>음식 이름</h1>
+      <p>뽑힌 음식 어때?</p>
+      <p>뽑힌 음식을 소개하는 글!</p>
+    </>
+  );
+}

--- a/src/FoodPage.jsx
+++ b/src/FoodPage.jsx
@@ -1,11 +1,21 @@
 import React from 'react';
 
+import { useHistory } from 'react-router-dom';
+
 export default function FoodPage() {
+  const history = useHistory();
+
+  function handleClick() {
+    const url = '/';
+    history.push(url);
+  }
+
   return (
     <>
       <h1>음식 이름</h1>
       <p>뽑힌 음식 어때?</p>
       <p>뽑힌 음식을 소개하는 글!</p>
+      <button type="button" onClick={handleClick}>다시 뽑기</button>
     </>
   );
 }

--- a/src/FoodPage.test.jsx
+++ b/src/FoodPage.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import FoodPage from './FoodPage';
+
+describe('FoodPage', () => {
+  function renderFoodPage() {
+    return render(<FoodPage />);
+  }
+
+  it('renders food name and description', () => {
+    const { container } = renderFoodPage();
+
+    expect(container).toHaveTextContent(/음식 이름/);
+
+    expect(container).toHaveTextContent(/어때?/);
+    expect(container).toHaveTextContent(/소개하는 글!/);
+  });
+});

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -1,12 +1,21 @@
 import React from 'react';
 
+import { useHistory } from 'react-router-dom';
+
 export default function HomePage() {
+  const history = useHistory();
+
+  function handleClick() {
+    const url = '/food';
+    history.push(url);
+  }
+
   return (
     <>
       <h1>오늘 뭐 먹지?!</h1>
       <p>무엇을 먹을지 고민이라면,</p>
       <p>오늘 한 끼 여기에 맡겨라!</p>
-      <button type="button">메뉴 뽑기</button>
+      <button type="button" onClick={handleClick}>메뉴 뽑기</button>
     </>
   );
 }

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function HomePage() {
+  return (
+    <>
+      <h1>오늘 뭐 먹지?!</h1>
+      <p>무엇을 먹을지 고민이라면,</p>
+      <p>오늘 한 끼 여기에 맡겨라!</p>
+      <button type="button">메뉴 뽑기</button>
+    </>
+  );
+}

--- a/src/HomePage.test.jsx
+++ b/src/HomePage.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import HomePage from './HomePage';
+
+describe('HomePage', () => {
+  function renderApp() {
+    return render(<HomePage />);
+  }
+
+  it('renders title and subtitle', () => {
+    const { container } = renderApp();
+
+    expect(container).toHaveTextContent(/오늘 뭐 먹지/);
+
+    expect(container).toHaveTextContent(/무엇을 먹을지 고민이라면/);
+    expect(container).toHaveTextContent(/오늘 한 끼 여기에 맡겨라/);
+  });
+
+  it('renders "메뉴 뽑기" button ', () => {
+    const { getByText } = renderApp();
+
+    const button = getByText('메뉴 뽑기');
+
+    expect(button).not.toBeNull();
+
+    fireEvent.click(button);
+  });
+});


### PR DESCRIPTION
## 한 일 
- 홈 페이지 구현
- 음식 페이지 구현 (선정된 메뉴를 보여주는 페이지)
- 라우팅 설정:
   1) "메뉴 뽑기" 시, 음식 페이지로 이동
   2) "다시 뽑기" 시, 홈 페이지로 이동.
- Grid Layout: CSS @Media를 통해 수정할 계획이지만, 대략 아래와 비슷하게 구현할 예정.
<img src="https://user-images.githubusercontent.com/37302935/99684458-d4f95a00-2ac4-11eb-85af-631027021fc0.png" width="90%">
<img src="https://user-images.githubusercontent.com/37302935/99684465-d75bb400-2ac4-11eb-8bb3-bc95fe29b2bc.png" width="40%">

## 할 일
1. "음식 데이터" 생성, 메뉴 선정을 위한 데이터.
2. "음식 페이지 이동 시", 랜덤으로 뽑힌 하나의 메뉴 텍스트 출력.
3. 단, "음식 페이지로 이동" 시, 트랜지션을 통한 화면 전환 구현.



