### PR TITLE
메뉴판 페이지 "특정 메뉴 검색" 기능 추가

### DIFF
--- a/src/Menus.jsx
+++ b/src/Menus.jsx
@@ -2,24 +2,29 @@ import React from 'react';
 
 import { isEmpty } from './utils';
 
-export default function Menus({ menus = [], checkedCategory = {} }) {
+export default function Menus({
+  menus = [],
+  checkedCategory = {},
+  searchedMenu = '',
+}) {
   if (!menus || isEmpty(menus)) {
     return <p>등록된 메뉴가 없습니다!</p>;
   }
 
+  const filteredMenus = (isEmpty(Object.keys(checkedCategory))
+    ? [...menus]
+    : menus.filter(({ category }) => category === checkedCategory.category))
+    .filter(({ name }) => name.includes(searchedMenu));
+
   return (
     <>
-      {menus.map(({ id, name, category }) => {
-        if (isEmpty(Object.keys(checkedCategory))
-          || category === checkedCategory.category) {
-          return (
-            <span key={id}>
-              {name}
-            </span>
-          );
-        }
-        return null;
-      })}
+      {isEmpty(filteredMenus)
+        ? null
+        : filteredMenus.map(({ id, name }) => (
+          <span key={id}>
+            {name}
+          </span>
+        ))}
     </>
   );
 }

--- a/src/Menus.test.jsx
+++ b/src/Menus.test.jsx
@@ -7,24 +7,82 @@ import { render } from '@testing-library/react';
 import Menus from './Menus';
 
 import FOODS from '../fixtures/foods';
+import CATEGORIES from '../fixtures/categories';
 
 describe('Menus', () => {
-  function renderFoodPage(checkedCategory) {
+  function renderMenus(checkedCategory, searchedMenu) {
     return render((
       <MemoryRouter>
         <Menus
           menus={FOODS}
           checkedCategory={checkedCategory}
+          searchedMenu={searchedMenu}
         />
       </MemoryRouter>
     ));
   }
 
-  it('renders menu list', () => {
-    const { container } = renderFoodPage();
+  context('without checked category and searched menu name', () => {
+    it('renders all menus', () => {
+      const { container } = renderMenus();
 
-    FOODS.forEach((food) => {
-      expect(container).toHaveTextContent(food.name);
+      FOODS.forEach(({ name }) => {
+        expect(container).toHaveTextContent(name);
+      });
+    });
+  });
+
+  context('with checked category', () => {
+    const checkedCategory = CATEGORIES[0];
+
+    it('renders menus by category', () => {
+      const { container } = renderMenus(checkedCategory);
+
+      const filteredMenus = FOODS.filter(({ category }) => category === checkedCategory.category);
+
+      filteredMenus.forEach(({ name }) => {
+        expect(container).toHaveTextContent(name);
+      });
+    });
+  });
+
+  context('with searched menu name', () => {
+    const searchedMenu = FOODS[0].name;
+
+    it('renders menus by menu name', () => {
+      const { container } = renderMenus({}, searchedMenu);
+
+      const filteredMenus = FOODS.filter(({ name }) => name.includes(searchedMenu));
+
+      filteredMenus.forEach(({ name }) => {
+        expect(container).toHaveTextContent(name);
+      });
+    });
+  });
+
+  context('with checked category and searched menu name', () => {
+    const checkedCategory1 = CATEGORIES[0];
+    const checkedCategory2 = CATEGORIES[2];
+    const searchedMenu = FOODS[0].name;
+
+    it('renders menus by menu name same category', () => {
+      const { container } = renderMenus(checkedCategory1, searchedMenu);
+
+      const filteredMenus = FOODS.filter(({ name }) => name.includes(searchedMenu));
+
+      filteredMenus.forEach(({ name }) => {
+        expect(container).toHaveTextContent(name);
+      });
+    });
+
+    it('renders menus by menu name different category', () => {
+      const { container } = renderMenus(checkedCategory2, searchedMenu);
+
+      const filteredMenus = FOODS.filter(({ name }) => name.includes(searchedMenu));
+
+      filteredMenus.forEach(({ name }) => {
+        expect(container).not.toHaveTextContent(name);
+      });
     });
   });
 });

--- a/src/MenusContainer.jsx
+++ b/src/MenusContainer.jsx
@@ -19,12 +19,14 @@ const MenusWapper = styled.div`
 export default function MenusContainer() {
   const menus = useSelector(get('foods')) || [];
   const checkedCategory = useSelector(get('checkedCategory')) || {};
+  const { menuName } = useSelector(get('menusFields')) || { menuName: '' };
 
   return (
     <MenusWapper>
       <Menus
         menus={menus}
         checkedCategory={checkedCategory}
+        searchedMenu={menuName}
       />
     </MenusWapper>
   );

--- a/src/MenusContainer.test.jsx
+++ b/src/MenusContainer.test.jsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { render } from '@testing-library/react';
 
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import MenusContainer from './MenusContainer';
 
@@ -23,31 +23,23 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('MenusContainer', () => {
-  const dispatch = jest.fn();
-
   beforeEach(() => {
-    dispatch.mockClear();
-
-    useDispatch.mockImplementation(() => dispatch);
-
     useSelector.mockImplementation((selector) => selector({
       foods: FOODS,
+      checkedCategory: {},
+      menusFields: { menuName: '' },
     }));
   });
 
-  function renderFoodPage() {
-    return render((
+  it('renders menu list', () => {
+    const { container } = render((
       <MemoryRouter>
         <MenusContainer />
       </MemoryRouter>
     ));
-  }
 
-  it('renders menu list', () => {
-    const { container } = renderFoodPage();
-
-    FOODS.forEach((menu) => {
-      expect(container).toHaveTextContent(menu.name);
+    FOODS.forEach(({ name }) => {
+      expect(container).toHaveTextContent(name);
     });
   });
 });

--- a/src/slice.js
+++ b/src/slice.js
@@ -36,12 +36,20 @@ const { actions, reducer } = createSlice({
       return {
         ...state,
         checkedCategory,
+        menusFields: {
+          ...state.menusFields,
+          menuName: '',
+        },
       };
     },
     clearCheckedCategory(state) {
       return {
         ...state,
         checkedCategory: {},
+        menusFields: {
+          ...state.menusFields,
+          menuName: '',
+        },
       };
     },
     changeMenuFields(state, { payload: { name, value } }) {


### PR DESCRIPTION
## 한 일
- 메뉴판 페이지에 "특정 메뉴 검색" 기능을 추가했다.
  이를 위해, 새로운 상태값을 추가했으며 onChange를 통해 사용자 입력에 따라 해당 단어를 포함하는 메뉴를 보여주도록 구현했다.

## 할 일
1. "메뉴판 페이지" emotion/styled를 통해 CSS를 적용할 예정이다!
2. "메뉴추천 페이지"에서 추천된 메뉴의 관련 요리들 보여주는 기능 구현할 예정이다!